### PR TITLE
Тест адекватного времени ответа сервера на k6

### DIFF
--- a/.github/workflows/k6-stability.yml
+++ b/.github/workflows/k6-stability.yml
@@ -7,7 +7,7 @@ jobs:
     name: Obtain Vercel preview deploy URL and run k6 test
     steps:
       - name: Wait for Vercel deploy
-        run: sleep 30
+        run: sleep 10
       - name: Obtain Vercel preview deploy URL
         uses: zentered/vercel-preview-url@v1.0.0
         id: vercel_preview_url
@@ -16,6 +16,15 @@ jobs:
         with:
           vercel_team_id: ${{ secrets.VERCEL_TEAM_ID }}
           vercel_project_id: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Awaiting Vercel deployment to be ready
+        uses: UnlyEd/github-action-await-vercel@v1.1.1
+        id: await-vercel
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEl_TOKEN }}
+        with:
+          deployment-url: ${{ steps.vercel_preview_url.outputs.preview_url }}
+          timeout: 120
 
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/k6-stability.yml
+++ b/.github/workflows/k6-stability.yml
@@ -1,0 +1,28 @@
+name: k6 stability test
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    name: Obtain Vercel preview deploy URL and run k6 test
+    steps:
+      - name: Wait for Vercel deploy
+        run: sleep 30
+      - name: Obtain Vercel preview deploy URL
+        uses: zentered/vercel-preview-url@v1.0.0
+        id: vercel_preview_url
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        with:
+          vercel_team_id: ${{ secrets.VERCEL_TEAM_ID }}
+          vercel_project_id: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Run k6 test
+        uses: k6io/action@v0.2.0
+        with:
+          filename: k6/tests/stability.js
+        env:
+          VERCEL_URL: ${{ steps.vercel_preview_url.outputs.preview_url }}

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -81,3 +81,5 @@ Development сервер, который запускается через `npm 
 ```
 $ npm run k6 --url=https://base-api-gooditworks.vercel.app
 ```
+
+Также отдельно лежат stress тесты, имитирующие максимальную нагрузку (`npm run k6:stress:*`), но их опасно запускать на Vercel, он может включить защиту от DDoS.

--- a/k6/tests/stability.js
+++ b/k6/tests/stability.js
@@ -1,0 +1,30 @@
+import gqlRequest from "../gql.js"
+
+const options = {
+  scenarios: {
+    stability: {
+      executor: "constant-arrival-rate",
+      duration: "10s",
+      gracefulStop: "1s",
+      preAllocatedVUs: 1,
+      maxVUs: 10,
+      rate: 5
+    }
+  },
+  thresholds: {
+    http_req_failed: ["rate<0.01"],
+    http_req_duration: ["p(95)<300"],
+  },
+}
+
+const test = gqlRequest({
+  url: __ENV.npm_config_url || __ENV.VERCEL_URL,
+  operation: "K6_Realistic",
+  query: "query K6_Realistic { health { realistic } }",
+  check: {
+    "response valid": data => data.health.realistic.startsWith("pony count")
+  }
+})
+
+export default test
+export {options}

--- a/k6/tests/stability.js
+++ b/k6/tests/stability.js
@@ -4,16 +4,16 @@ const options = {
   scenarios: {
     stability: {
       executor: "constant-arrival-rate",
-      duration: "10s",
+      duration: "30s",
       gracefulStop: "1s",
       preAllocatedVUs: 1,
-      maxVUs: 10,
-      rate: 5
+      maxVUs: 5,
+      rate: 1
     }
   },
   thresholds: {
     http_req_failed: ["rate<0.01"],
-    http_req_duration: ["p(95)<300"],
+    http_req_duration: ["med<300"],
   },
 }
 

--- a/k6/tests/stability.js
+++ b/k6/tests/stability.js
@@ -4,7 +4,7 @@ const options = {
   scenarios: {
     stability: {
       executor: "constant-arrival-rate",
-      duration: "30s",
+      duration: "3m",
       gracefulStop: "1s",
       preAllocatedVUs: 1,
       maxVUs: 5,

--- a/k6/tests/stability.js
+++ b/k6/tests/stability.js
@@ -18,7 +18,7 @@ const options = {
 }
 
 const test = gqlRequest({
-  url: __ENV.npm_config_url || __ENV.VERCEL_URL,
+  url: __ENV.npm_config_url || `https://${__ENV.VERCEL_URL}`,
   operation: "K6_Realistic",
   query: "query K6_Realistic { health { realistic } }",
   check: {

--- a/k6/tests/stability.js
+++ b/k6/tests/stability.js
@@ -4,7 +4,7 @@ const options = {
   scenarios: {
     stability: {
       executor: "constant-arrival-rate",
-      duration: "3m",
+      duration: "5m",
       gracefulStop: "1s",
       preAllocatedVUs: 1,
       maxVUs: 5,

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
     "migrate": "sh ./scripts/migrate.sh",
     "release": "standard-version",
     "commit": "git add . && cz",
-    "k6": "concurrently -m 1 -c green \"npm:k6:*\"",
-    "k6:empty": "k6 run -q k6/tests/empty.js",
-    "k6:realistic": "k6 run -q k6/tests/realistic.js",
-    "k6:slow": "k6 run -q --log-output=none k6/tests/slow.js"
+    "k6": "k6 run k6/tests/stability.js",
+    "k6:stress:empty": "k6 run -q k6/tests/empty.js",
+    "k6:stress:realistic": "k6 run -q k6/tests/realistic.js",
+    "k6:stress:slow": "k6 run -q --log-output=none k6/tests/slow.js"
   },
   "devDependencies": {
     "@arkweid/lefthook": "^0.7.6",


### PR DESCRIPTION
## Описание изменений

- Добавлен новый тест k6, по факту тот же `realistic`, но с минимальным количеством RPS (сейчас 5)
- Также добавлен Github Action запускающий его на инфраструктуре Github
