### PR TITLE
fix(prisma): Клиент Prisma перенесён из дефолтной директории

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@
 /.env
 /build
 /public/docs
-/prisma/client
+/src/generated/prisma
 .vercel

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /.env
 /build
 /public/docs
+/prisma/client
+.vercel

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,7 +8,7 @@ datasource db {
 generator client {
   provider = "prisma-client-js"
   previewFeatures = ["referentialIntegrity"]
-  output = "./client"
+  output = "../src/generated/prisma"
 }
 
 enum PonyRace {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,6 +8,7 @@ datasource db {
 generator client {
   provider = "prisma-client-js"
   previewFeatures = ["referentialIntegrity"]
+  output = "./client"
 }
 
 enum PonyRace {

--- a/src/prisma.ts
+++ b/src/prisma.ts
@@ -1,4 +1,4 @@
-import {PrismaClient} from "@prisma/client"
+import {PrismaClient} from "../prisma/client"
 
 const client = new PrismaClient()
 

--- a/src/prisma.ts
+++ b/src/prisma.ts
@@ -1,4 +1,4 @@
-import {PrismaClient} from "../prisma/client"
+import {PrismaClient} from "./generated/prisma"
 
 const client = new PrismaClient()
 


### PR DESCRIPTION
## Описание изменений

- [x] Добавлен output параметр в конфигурацию клиента prisma. Теперь типы и клиент будут выводиться в `src/generated/prisma`. Сама папка добавлена в .gitignore

Ссылка на документацию, откуда взят пример для конфигурации: https://www.prisma.io/docs/concepts/components/prisma-client/working-with-prismaclient/generating-prisma-client#the-location-of-prisma-client

## Чеклист

- [ ] Обновлена документация в docs/
- [ ] Обновлена документация проекта в Notion
